### PR TITLE
Changing "direction" access modifier to public

### DIFF
--- a/GradientView/GradientView.swift
+++ b/GradientView/GradientView.swift
@@ -82,7 +82,7 @@ import UIKit
   #endif
   
   /// The direction of the gradient. Only valid for the `Mode.Linear` mode. The default is `.Vertical`.
-  var direction: Direction = .vertical
+  public var direction: Direction = .vertical
   #if TARGET_INTERFACE_BUILDER
   @IBInspectable open var direction: Direction = .vertical {
   didSet {


### PR DESCRIPTION
Changing "direction" variable access modifier to public (default was internal). This wasn't allowing us to change gradientview direction.